### PR TITLE
Refactor Promise.reduce

### DIFF
--- a/.todo
+++ b/.todo
@@ -1,0 +1,2 @@
+* eslint or prettier ?
+* commit styles ?

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "nativebird",
   "description": "Ultralight promise extension compatible with Bluebird",
   "type": "module",
-  "version": "1.2.4",
+  "version": "1.2.5",
   "author": "Yifeng Wang",
   "repository": "https://github.com/doodlewind/nativebird.git",
   "main": "./promise.mjs",

--- a/promise.mjs
+++ b/promise.mjs
@@ -164,7 +164,7 @@ NPromise.reduce = async function reduce(iterable, fn, initialValue) {
     while ((item = iterator.next(), !item.done)) {
       ret = (++idx === 0 && ret === undefined)
         ? await item.value
-        : await fn(ret, item.value, idx, list)
+        : await fn(ret, item.value, idx, list.length)
     }
     return ret;
   });

--- a/promise.mjs
+++ b/promise.mjs
@@ -43,7 +43,7 @@ class NPromise extends Promise {
   spread(fn) {
     return this.then(function () {
       if (typeof fn !== "function") {
-        throw new TypeError("Promise.spread requires function, but got", typeof fn);
+        throw new TypeError(`Promise.spread requires function, but got ${typeof fn}`);
       }
 
       if (!arguments || arguments.length === 0) {
@@ -66,7 +66,7 @@ NPromise.try = function (fn) {
   return new NPromise(function (resolve, reject) {
     if (typeof fn !== "function") {
       reject(
-        new TypeError("Promise.try requires function, but got", typeof fn)
+        new TypeError(`Promise.try requires function, but got ${typeof fn}`)
       );
     }
     resolve(fn());
@@ -75,7 +75,7 @@ NPromise.try = function (fn) {
 
 NPromise.each = async function each(arr, fn) {
   if (!Array.isArray(arr)) {
-    throw new TypeError("Promise.each requires array, but got", typeof arr);
+    throw new TypeError(`Promise.each requires array, but got ${typeof arr}`);
   }
   const values = [];
   for (let i = 0; i < arr.length; i++) {
@@ -88,7 +88,7 @@ NPromise.each = async function each(arr, fn) {
 
 NPromise.mapSeries = function mapSeries(arr, fn) {
   if (!Array.isArray(arr)) {
-    throw new TypeError("Promise.mapSeries requires array, but got", typeof arr);
+    throw new TypeError(`Promise.mapSeries requires array, but got ${typeof arr}`);
   }
   return new NPromise(async (resolve) => {
     const results = [];
@@ -110,7 +110,7 @@ NPromise.map = function map(iterable, fn, options) {
   if ("then" in iterable) {
     return iterable.then((arr) => {
       if (!Array.isArray(arr)) {
-        throw new TypeError("Promise.map requires array, but got", typeof arr);
+        throw new TypeError(`Promise.map requires array, but got ${typeof arr}`);
       }
       return NPromise.map(arr, fn, options);
     });
@@ -154,7 +154,7 @@ NPromise.defer = function defer() {
 
 NPromise.reduce = async function reduce(iterable, fn, initialValue) {
   if (typeof fn !== 'function') {
-    throw new TypeError('Promise.reduce requires function, but got', typeof fn)
+    throw new TypeError(`Promise.reduce requires function, but got ${typeof fn}`)
   }
   return NPromise.all(await iterable).then(async (list) => {
     const iterator = list[Symbol.iterator]();

--- a/promise.mjs
+++ b/promise.mjs
@@ -43,7 +43,7 @@ class NPromise extends Promise {
   spread(fn) {
     return this.then(function () {
       if (typeof fn !== "function") {
-        throw new TypeError("Promise.spread requires function");
+        throw new TypeError("Promise.spread requires function, but got", typeof fn);
       }
 
       if (!arguments || arguments.length === 0) {
@@ -65,14 +65,18 @@ NPromise.delay = function delay(ms = 0, value) {
 NPromise.try = function (fn) {
   return new NPromise(function (resolve, reject) {
     if (typeof fn !== "function") {
-      reject(new TypeError("Promise.try requires function"));
+      reject(
+        new TypeError("Promise.try requires function, but got", typeof fn)
+      );
     }
     resolve(fn());
   });
 };
 
 NPromise.each = async function each(arr, fn) {
-  if (!Array.isArray(arr)) throw new TypeError("Promise.each requires array");
+  if (!Array.isArray(arr)) {
+    throw new TypeError("Promise.each requires array, but got", typeof arr);
+  }
   const values = [];
   for (let i = 0; i < arr.length; i++) {
     const val = await NPromise.resolve(arr[i]);
@@ -84,7 +88,7 @@ NPromise.each = async function each(arr, fn) {
 
 NPromise.mapSeries = function mapSeries(arr, fn) {
   if (!Array.isArray(arr)) {
-    throw new TypeError("Promise.mapSeries requires array");
+    throw new TypeError("Promise.mapSeries requires array, but got", typeof arr);
   }
   return new NPromise(async (resolve) => {
     const results = [];
@@ -106,7 +110,7 @@ NPromise.map = function map(iterable, fn, options) {
   if ("then" in iterable) {
     return iterable.then((arr) => {
       if (!Array.isArray(arr)) {
-        throw new TypeError("Promise.map requires array");
+        throw new TypeError("Promise.map requires array, but got", typeof arr);
       }
       return NPromise.map(arr, fn, options);
     });

--- a/test/reduce.mjs
+++ b/test/reduce.mjs
@@ -614,8 +614,21 @@ describe("Promise.reduce-test", function () {
     );
   });
 
-  specify("should resolve to initialValue Promise input promise does not resolve to an array", function () {
-    return Promise.reduce(Promise.resolve(123), plus, 1).catch(TypeError, function (e) {
+  specify("should throw TypeError if input promise does not resolve to an array", function () {
+    let catched = null;
+    return Promise.reduce(Promise.resolve(123), plus, 1).catch(err => {
+      catched = err;
+    }).then(() => {
+      assert(catched instanceof TypeError);
+    });
+  });
+
+  specify("should throw TypeError if input reducer is not a function", function () {
+    let catched = null;
+    return Promise.reduce([], 123, 1).catch(err => {
+      catched = err;
+    }).then(() => {
+      assert(catched instanceof TypeError);
     });
   });
 

--- a/test/reduce.mjs
+++ b/test/reduce.mjs
@@ -122,7 +122,25 @@ var VALUES_CRITERIA = [
       promising(3),
       4
     ], total: 10, desc: "and a blend of values"
+  }
+];
+
+var STRING_CRITERIA = [
+  {
+    value: '',
+    total: 0,
+    desc: "not iterates over empty string"
   },
+  {
+    value: '1',
+    total: '015',
+    desc: "iterates over a char"
+  },
+  {
+    value: '123',
+    total: '0152535',
+    desc: "iterates over a string"
+  }
 ];
 
 var ERROR = new Error("BOOM");
@@ -131,7 +149,7 @@ var ERROR = new Error("BOOM");
 describe("Promise.prototype.reduce", function () {
   it("works with no values", function () {
     return Promise.resolve([]).reduce(function (total, value) {
-      return total + value + 5;
+      return total + value + assert.fail();
     }).then(function (total) {
       assert.strictEqual(total, undefined);
     });
@@ -226,7 +244,7 @@ describe("Promise.reduce", function () {
   describe("with no initial accumulator or values", function () {
     it("works when the iterator returns a value", function () {
       return Promise.reduce([], function (total, value) {
-        return total + value + 5;
+        return total + value + assert.fail();
       }).then(function (total) {
         assert.strictEqual(total, undefined);
       });
@@ -235,7 +253,7 @@ describe("Promise.reduce", function () {
     it("works when the iterator returns a Promise", function () {
       return Promise.reduce([], function (total, value) {
         return promised(5).then(function (bonus) {
-          return total + value + bonus;
+          return total + value + bonus + assert.fail();
         });
       }).then(function (total) {
         assert.strictEqual(total, undefined);
@@ -244,7 +262,7 @@ describe("Promise.reduce", function () {
 
     it("works when the iterator returns a thenable", function () {
       return Promise.reduce([], function (total, value) {
-        return thenabled(total + value + 5);
+        return thenabled(total + value + assert.fail());
       }).then(function (total) {
         assert.strictEqual(total, undefined);
       });
@@ -256,6 +274,7 @@ describe("Promise.reduce", function () {
       var initial = criteria.value;
 
       describe(criteria.desc, function () {
+
         VALUES_CRITERIA.forEach(function (criteria) {
           var values = criteria.value;
           var valueTotal = criteria.total;
@@ -288,6 +307,40 @@ describe("Promise.reduce", function () {
             });
           });
         });
+
+        STRING_CRITERIA.forEach(function (criteria) {
+          var values = criteria.value;
+          var valueTotal = criteria.total;
+
+          describe(criteria.desc, function () {
+            it("works when the iterator returns a value", function () {
+              return Promise.reduce(evaluate(values), function (total, value) {
+                return total + value + 5;
+              }, evaluate(initial)).then(function (total) {
+                assert.strictEqual(total, valueTotal);
+              });
+            });
+
+            it("works when the iterator returns a Promise", function () {
+              return Promise.reduce(evaluate(values), function (total, value) {
+                return promised(5).then(function (bonus) {
+                  return total + value + bonus;
+                });
+              }, evaluate(initial)).then(function (total) {
+                assert.strictEqual(total, valueTotal);
+              });
+            });
+
+            it("works when the iterator returns a thenable", function () {
+              return Promise.reduce(evaluate(values), function (total, value) {
+                return thenabled(total + value + 5);
+              }, evaluate(initial)).then(function (total) {
+                assert.strictEqual(total, valueTotal);
+              });
+            });
+          });
+        });
+
       });
     });
 
@@ -301,7 +354,7 @@ describe("Promise.reduce", function () {
       ];
 
       return Promise.reduce(values, function (total, value) {
-        return value;
+        return assert.fail();
       }, initial).then(assert.fail, function (err) {
         assert.equal(err, ERROR);
       });
@@ -365,6 +418,7 @@ describe("Promise.reduce", function () {
       var zeroth = criteria.value;
 
       describe(criteria.desc, function () {
+
         VALUES_CRITERIA.forEach(function (criteria) {
           var values = criteria.value;
           var zerothAndValues = [zeroth].concat(values);
@@ -398,6 +452,7 @@ describe("Promise.reduce", function () {
             });
           });
         });
+
       });
     });
 


### PR DESCRIPTION
* refactor：使用 symbol.iterator 重构 Promies.reduce 以支持在字符串上的遍历
* fix：Promies.reduce 中，reducer 函数的第四个参数应为数组长度，而不是数组本身
* refactor：更好的报错提示
* testcases