### PR TITLE
fix: esm & types

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,12 +5,12 @@
   "version": "1.2.11",
   "author": "Yifeng Wang",
   "repository": "https://github.com/doodlewind/nativebird.git",
-  "main": "./promise.mjs",
+  "module": "./promise.mjs",
+  "main": "./dist/promise.cjs",
   "exports": {
-    ".": {
       "require": "./dist/promise.cjs",
-      "import": "./promise.mjs"
-    }
+      "import": "./promise.mjs",
+      "types": "./index.d.ts"
   },
   "files": [
     "promise.mjs",


### PR DESCRIPTION
right now nativebird's types can't be found if you use `Bundler` for typescript moduleResolution

and also `main` is a field for CommonJS, putting ESM there is invalid. `"module"` should be used instead.

More info here: https://publint.dev/nativebird@1.2.11